### PR TITLE
Consolidate link selectors and footer hover color

### DIFF
--- a/css/03-generic.css
+++ b/css/03-generic.css
@@ -39,7 +39,7 @@
 	background-color: var( --color-brandRed );
 }
 
-a:hover, a:active, .main-navigation .main-menu > li > a:hover, .main-navigation .main-menu > li > a:hover + svg, .post-navigation .nav-links a:hover, .post-navigation .nav-links a:hover .post-title, .author-bio .author-description .author-link:hover, .entry .entry-content > .has-secondary-color, .entry .entry-content > [class^="wp-block-"] .has-secondary-color, .entry .entry-content > [class^="wp-block-"].is-style-solid-color blockquote.has-secondary-color, .entry .entry-content > [class^="wp-block-"].is-style-solid-color blockquote.has-secondary-color p, .comment .comment-author .fn a:hover, .comment-reply-link:hover, .comment-navigation .nav-previous a:hover, .comment-navigation .nav-next a:hover, #cancel-comment-reply-link:hover, .widget a:hover {
+a, a:hover, a:active, a:visited, #colophon .site-info a:hover, .main-navigation .main-menu > li > a:hover, .main-navigation .main-menu > li > a:hover + svg, .post-navigation .nav-links a:hover, .post-navigation .nav-links a:hover .post-title, .author-bio .author-description .author-link:hover, .entry .entry-content > .has-secondary-color, .entry .entry-content > [class^="wp-block-"] .has-secondary-color, .entry .entry-content > [class^="wp-block-"].is-style-solid-color blockquote.has-secondary-color, .entry .entry-content > [class^="wp-block-"].is-style-solid-color blockquote.has-secondary-color p, .entry .entry-footer a:hover, .comment .comment-author .fn a:hover, .comment-reply-link:hover, .comment-navigation .nav-previous a:hover, .comment-navigation .nav-next a:hover, #cancel-comment-reply-link:hover, .widget a:hover {
 	color: var( --color-brandRed );
 }
 
@@ -220,13 +220,4 @@ h4 {
 /* remove space between blog quotes and featured image */
 .entry-content .wp-block-pullquote:first-child {
 	margin-top: 0;
-}
-
-/* Link Colors */
-a, 
-a:visited,
-a:hover,
-a:active,
-.entry .entry-footer a:hover {
-	color: var( --color-brandRed );
 }


### PR DESCRIPTION
Aside from consolidating selectors, I noticed that the page footer links were blue on hover, so I added `#colophon .site-info a:hover` to fix that.