### PR TITLE
fix: clearfix for advising page

### DIFF
--- a/css/03-generic.css
+++ b/css/03-generic.css
@@ -221,3 +221,10 @@ h4 {
 .entry-content .wp-block-pullquote:first-child {
 	margin-top: 0;
 }
+
+/* Block Image and Paragraph Clearfix */
+.wp-block-image + p::after {
+	content: "";
+	clear: both;
+	display: table;
+}


### PR DESCRIPTION
Solving #61, I am leaving the clearfix on a pseudo `::after` element as opposed to the` hr` block separator because placing it on the `hr` eliminates the margin below the paragraph and image on wider screens.