### PR TITLE
Remove white space to the left of featured-image on mobile

### DIFF
--- a/css/03-generic.css
+++ b/css/03-generic.css
@@ -51,6 +51,8 @@ a, a:hover, a:active, a:visited, #colophon .site-info a:hover, .main-navigation 
 	background: black;
 	padding-top: 2rem;
 	padding-bottom: 2rem;
+	padding-left: 1rem;
+	padding-right: 1rem;
 }
 
 .site-content {
@@ -143,6 +145,7 @@ body.home header.entry-header {
 
 .site-header.featured-image {
 	min-height: 70vh;
+	padding: 0;
 }
 
 .featured-image .site-description {


### PR DESCRIPTION
Fixes #63 