### PR TITLE
Clip-paths for buttons

### DIFF
--- a/css/03-generic.css
+++ b/css/03-generic.css
@@ -290,34 +290,21 @@ input[type="reset"],
 input[type="submit"] {
 	background-color: var( --color-brandRed );
 	border-radius: 0;
-	box-shadow: 5px 5px 0px 0px var( --color-brandGrey );
-		-webkit-box-shadow: 5px 5px 0px 0px var( --color-brandGrey );
-		-moz-box-shadow: 5px 5px 0px 0px var( --color-brandGrey );
 	font-family: 'roboto_slablight', Georgia, serif;	
 }
 
-button:hover, 
-.button:hover, 
-.entry .button:hover, 
-.entry .entry-content .wp-block-file .wp-block-file__button:hover,
-.entry .entry-content .wp-block-button .wp-block-button__link:hover,
-input[type="button"]:hover, 
-input[type="reset"]:hover, 
-input[type="submit"]:hover {
-	background-color: var( --color-brandGrey );
-		-webkit-box-shadow: none;
-		-moz-box-shadow: none;
-	box-shadow: none;
-}
+/* outline buttons overrides
 
-/* outline buttons overrides */
+	border will be applied on the parent element to avoid it being cut by clip-paths
+	background inserted to hide filterr: dropshadow property inside the button
+
+ */
 
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color):hover {
-	border-color: var( --color-brandRed );
-	color: var( --color-brandRed )
-}
-
-.entry .entry-content .wp-block-button:not(.is-style-squared) .wp-block-button__link {
-	border-radius: 0;
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color):hover,
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color):focus,
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color):visited {
+	border: none;
+	color: var( --color-brandRed );
+	background-color: var( --color-brandBeige );
 }

--- a/css/03-generic.css
+++ b/css/03-generic.css
@@ -277,7 +277,7 @@ blockquote a, blockquote a:hover, blockquote a:active, blockquote a:visited {
 
 /* Buttons */
 
-/* all buttons overrides */
+/* default buttons overrides */
 
 button, 
 .button, 
@@ -288,9 +288,20 @@ button,
 input[type="button"], 
 input[type="reset"], 
 input[type="submit"] {
+	transition: all 150ms ease-in-out;
 	background-color: var( --color-brandRed );
 	border-radius: 0;
 	font-family: 'roboto_slablight', Georgia, serif;	
+}
+
+button:hover,
+.button:hover, 
+.wp-block-file__button:hover,
+.wp-block-button:not(.is-style-outline) .wp-block-button__link:hover,
+input[type="button"]:hover, 
+input[type="reset"]:hover, 
+input[type="submit"]:hover{
+	filter: brightness(80%);
 }
 
 /* outline buttons overrides

--- a/css/03-generic.css
+++ b/css/03-generic.css
@@ -301,6 +301,7 @@ button:hover,
 input[type="button"]:hover, 
 input[type="reset"]:hover, 
 input[type="submit"]:hover{
+	background-color: var( --color-brandRed );
 	filter: brightness(80%);
 }
 

--- a/css/c4aa-clipPaths.css
+++ b/css/c4aa-clipPaths.css
@@ -1,7 +1,16 @@
-h2, h3, h4 {
-    color: var( --color-brandBeige );
+h2, 
+h3, 
+h4,
+button,
+.button, 
+.wp-block-file__button,
+.wp-block-button:not(.is-style-outline),
+.entry .entry-content .wp-block-button .wp-block-button__link,
+.wp-block-button__link,
+input[type="button"], 
+input[type="reset"], 
+input[type="submit"] {
 	padding: var(--topPadding) var(--rightPadding) var(--bottomPadding) var(--leftPadding);
-	position: relative;
 	clip-path: polygon( 
 		calc( var( --topLeftX ) * 1px ) 
 		calc( var( --topLeftY ) * 1px ), 
@@ -16,6 +25,10 @@ h2, h3, h4 {
 }
 
 /* Headers */
+
+h2, h3, h4 {
+	color: var( --color-brandBeige );
+}
  
 h2 {
 	background: var( --color-brandGrey );
@@ -57,4 +70,52 @@ h4 {
 		margin-left: -4rem;
 		--leftPadding: 4rem;
 	}
+}
+
+/* Buttons */
+
+button,
+.button, 
+.wp-block-file__button,
+.wp-block-button:not(.is-style-outline),
+.entry .entry-content .wp-block-button .wp-block-button__link,
+.wp-block-button__link,
+input[type="button"], 
+input[type="reset"], 
+input[type="submit"] {
+	--topPadding: 1.5rem;
+	--bottomPadding: 1.5rem;
+	--leftPadding:  1.5rem;
+	--rightPadding: 1.5rem;
+}
+
+
+.c4aa-default-button-wrapper {
+	filter: drop-shadow(5px 5px 0px var( --color-brandGrey ));
+	height: fit-content;
+	transition: all 150ms ease-in-out;
+	width: fit-content;
+}
+
+.c4aa-default-button-wrapper:hover {
+	filter: none;
+}
+
+.c4aa-outline-button-wrapper  {
+	filter:	drop-shadow(-2px 0px 0px var( --color-brandRed ))
+			drop-shadow(0px -2px 0px var( --color-brandRed ))
+			drop-shadow(2px 0px 0px var( --color-brandRed ))
+			drop-shadow(0px 2px 0px var( --color-brandRed ))
+			drop-shadow(5px 5px 0px var( --color-brandGrey )
+	);
+	height: fit-content;
+	transition: all 150ms ease-in-out;
+	width: fit-content;
+}
+
+.c4aa-outline-button-wrapper:hover {
+	filter:	drop-shadow(-2px 0px 0px var( --color-brandRed ))
+			drop-shadow(0px -2px 0px var( --color-brandRed ))
+			drop-shadow(2px 0px 0px var( --color-brandRed ))
+			drop-shadow(0px 2px 0px var( --color-brandRed ));
 }

--- a/css/c4aa-clipPaths.css
+++ b/css/c4aa-clipPaths.css
@@ -89,7 +89,6 @@ input[type="submit"] {
 	--rightPadding: 1.5rem;
 }
 
-
 .c4aa-default-button-wrapper {
 	filter: drop-shadow(5px 5px 0px var( --color-brandGrey ));
 	height: fit-content;

--- a/js/script.js
+++ b/js/script.js
@@ -30,13 +30,13 @@ defaultButtons.forEach( ( button ) => {
 
 	// create container for dropshadow
 	let wrapShadow = document.createElement('div');
-	wrapShadow.setAttribute('class', 'c4aa-default-button-wrapper' );
+	wrapShadow.setAttribute( 'class', 'c4aa-default-button-wrapper' );
 
 	// insert container before button in the DOM tree
-	button.parentNode.insertBefore(wrapShadow, button);
+	button.parentNode.insertBefore( wrapShadow, button );
 
 	// move button into container
-	wrapShadow.appendChild(button);
+	wrapShadow.appendChild( button );
 
 	// add clip path css properties
 	clipProperties.forEach( ( property ) => {
@@ -48,7 +48,7 @@ defaultButtons.forEach( ( button ) => {
 // add outline and shadow
 outlineButtons.forEach( ( button ) => {
 
-	button.classList.add('c4aa-outline-button-wrapper');
+	button.classList.add( 'c4aa-outline-button-wrapper' );
 
 });
 
@@ -65,8 +65,9 @@ outlineButtonsLink.forEach( ( link) => {
 /* Helper Function 
 
 	if no fixedPoint is set, then this function will generate an integer
-	
+
 */
+
 function getRandomNum( min, max, fixedPoint = 0 ) {
   min = Math.ceil( min );
   max = Math.floor( max );

--- a/js/script.js
+++ b/js/script.js
@@ -1,17 +1,72 @@
 const headings = document.querySelectorAll( 'h2, h3, h4' );
+const defaultButtons = document.querySelectorAll( 'button, .button, .wp-block-file__button, .wp-block-button:not(.is-style-outline), input[type="button"], input[type="reset"], input[type="submit"]' );
+const outlineButtons =   document.querySelectorAll( '.wp-block-button.is-style-outline');
+const outlineButtonsLink = document.querySelectorAll( '.wp-block-button.is-style-outline .wp-block-button__link');
+const clipProperties = ['--topLeftX', '--topLeftY', '--topRightX', '--topRightY', '--bottomLeftX', '--bottomLeftY', '--bottomRightX', '--bottomRightY' ];
 
-let clipProperties = ['--topLeftX', '--topLeftY', '--topRightX', '--topRightY', '--bottomLeftX', '--bottomLeftY', '--bottomRightX', '--bottomRightY' ];
+/* Heading Clip Paths */
 
 headings.forEach( ( heading ) => {
+
+	// rotate headings
 	heading.style.setProperty( '--rotate', getRandomNum( -1.5, 2, 3 ) );
-		
+	
+	// add clip path css properties
 	clipProperties.forEach( ( property ) => {
 			heading.style.setProperty( property, getRandomNum( 10, 20) );
 	});
 	
 });
 
-//if no fixedPoint is set, then this function will generate an integer
+
+/* Button Clip Paths 
+
+	because clip-paths eliminates drop shadows and borders, 
+	wrappers are added to buttons to contain these properties
+
+*/
+
+defaultButtons.forEach( ( button ) => {
+
+	// create container for dropshadow
+	let wrapShadow = document.createElement('div');
+	wrapShadow.setAttribute('class', 'c4aa-default-button-wrapper' );
+
+	// insert container before button in the DOM tree
+	button.parentNode.insertBefore(wrapShadow, button);
+
+	// move button into container
+	wrapShadow.appendChild(button);
+
+	// add clip path css properties
+	clipProperties.forEach( ( property ) => {
+			button.style.setProperty( property, getRandomNum( 10, 20) );
+	});
+	
+});
+
+// add outline and shadow
+outlineButtons.forEach( ( button ) => {
+
+	button.classList.add('c4aa-outline-button-wrapper');
+
+});
+
+
+outlineButtonsLink.forEach( ( link) => {
+	
+	clipProperties.forEach( ( property ) => {
+			link.style.setProperty( property, getRandomNum( 10, 20) );
+	});
+	
+});
+
+
+/* Helper Function 
+
+	if no fixedPoint is set, then this function will generate an integer
+	
+*/
 function getRandomNum( min, max, fixedPoint = 0 ) {
   min = Math.ceil( min );
   max = Math.floor( max );


### PR DESCRIPTION
This completes #11 by adding clip-paths to the buttons, and making them darker on :hover. 

Because the clip-path property cuts box-shadows and borders, I had to insert a wrapper on each button.