### PR TITLE
small refactor: unifying use of brandbeige

### DIFF
--- a/css/00-settings.css
+++ b/css/00-settings.css
@@ -1,6 +1,7 @@
 :root {
 	/* Brand Colors */
-	--color-brandBeige: #e8e6df;
+	--color-brandBeige: #F2F1ED; /* Fallback */
+	--color-brandBeige: hsla(48, 16%, 94%, 1);
 	--color-brandBlack: #292724; /* Fallback */
 	--color-brandBlack: hsla(36, 6%, 5%, 0.9);
 	--color-brandBlue: #005eb8; /* Fallback */

--- a/css/03-generic.css
+++ b/css/03-generic.css
@@ -55,7 +55,7 @@ a, a:hover, a:active, a:visited, #colophon .site-info a:hover, .main-navigation 
 }
 
 .site-content {
-	background-color: rgba(228, 226, 218, 0.50);
+	background-color: var( --color-brandBeige);
 }
 
 


### PR DESCRIPTION
I created an HSLA equivalent of our beige. I'm keeping it full opacity because beige text with transparency over red or black would have less contrast.

Also brightened our beige for more contrast/accessibility.

Set background of .site-content in 03-generic.css from an rgba value to brandBeige