### PR TITLE
This just takes off "HOME" from the homepage.

### DIFF
--- a/css/03-generic.css
+++ b/css/03-generic.css
@@ -128,7 +128,7 @@ h4 {
 
 /* Remove H1 from home */
 
-body.home header.entry-header, .imprint {
+body.home .entry-header h1.entry-title {
 	position:absolute;
 	left: -10000px;
 	top: auto;


### PR DESCRIPTION
@laras126 .imprint is what showed "powered by WordPress" in the footer. Since we have our own footer.php file that doesn't include that, it's no longer needed.