### PR TITLE
feat: adding styles for accordion buttons

### DIFF
--- a/build/main.css
+++ b/build/main.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 :root {
   /* Brand Colors */
   --color-brandBeige: #F2F1ED;
@@ -549,6 +550,20 @@ input[type="radio"]:checked + label::before {
 
 form[id*="give-form"] #give-donation-level-radio-list > li {
   display: inline-flex; }
+
+/* Accordion Buttons */
+.c-accordion__title--button {
+  font-style: italic;
+  text-decoration: underline; }
+
+.c-accordion__title--button::after {
+  content: "▼";
+  color: var(--color-brandRed);
+  right: auto;
+  margin-left: 1em; }
+
+.is-open .c-accordion__title::after {
+  content: "▲"; }
 
 /***********/
 /* Archive */

--- a/src/css/_03-generic.scss
+++ b/src/css/_03-generic.scss
@@ -511,6 +511,7 @@ input[type="radio"]:checked + label::before {
 	text-transform: capitalize;
 }
 
+
 /* Allow image blocks to actually be full width */
 
 .entry .entry-content .wp-block-image {
@@ -525,3 +526,21 @@ form[id*="give-form"] #give-donation-level-radio-list > li {
 	display: inline-flex;
 }
 
+
+/* Accordion Buttons */
+
+.c-accordion__title--button {
+	font-style: italic;
+	text-decoration: underline;
+}
+
+.c-accordion__title--button::after {
+	content: "▼";
+	color: var( --color-brandRed );
+	right: auto;
+	margin-left: 1em;
+}
+
+.is-open .c-accordion__title::after {
+    content: "▲";
+    }


### PR DESCRIPTION
These are being used on /about so we can have longer bios accordion down to something more brief.

I added text based arrows (svgs got complicated to color)

<img width="736" alt="Screen Shot 2020-03-29 at 11 42 13 AM" src="https://user-images.githubusercontent.com/67271/77853494-63297480-71b2-11ea-9431-9efff899dff1.png">

<img width="504" alt="Screen Shot 2020-03-29 at 11 42 20 AM" src="https://user-images.githubusercontent.com/67271/77853492-6290de00-71b2-11ea-92fd-58d709a27bd7.png">