### PR TITLE
fix: display magic hand icon in footer

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -36,7 +36,7 @@
 				
 			<div class="c4aa-magic-hand u-text-align-center">
 
-				<div class="u-display-inline-block">
+				<div class="u-display-block">
 					<?php echo file_get_contents( get_stylesheet_directory() . '/svg/c4aa.magic.hand.svg' ); ?>
 				</div>
 

--- a/src/css/_05-utilities.css
+++ b/src/css/_05-utilities.css
@@ -1,34 +1,40 @@
 /* Algorithms */
 
 .a-colophon-grid {
-	display: grid;
-	grid-gap: 1rem;
+  display: grid;
+  grid-gap: 1rem;
 }
 
-@media( min-width: 800px ) {
-	.a-colophon-grid {
-		grid-template-columns: 1fr 80px 1fr;
-	}
+@media (min-width: 800px) {
+  .a-colophon-grid {
+    grid-template-columns: 1fr 80px 1fr;
+  }
 }
 
 /* Utilities */
 
 .no-hyphens * {
-     hyphens: manual;
+  -webkit-hyphens: manual;
+  -ms-hyphens: manual;
+  hyphens: manual;
 }
 
 .u-display-inline-block {
-	display: inline-block;
+  display: inline-block;
+}
+
+.u-display-block {
+  display: block;
 }
 
 .u-text-align-center {
-	text-align: center;
+  text-align: center;
 }
 
 .u-align-items-center {
-	align-items: center;
+  align-items: center;
 }
 
 .u-text-align-right {
-	text-align: right;
+  text-align: right;
 }


### PR DESCRIPTION
Resolves [Issue 241: Magic Hand missing from footer ](https://github.com/thec4aa/c4aa-org/issues/241)
- Replace CSS to make icon visible
- Create new CSS utility class to apply display style

<img width="750" alt="c4aa-magic-hand-footer" src="https://github.com/thec4aa/c4aa-org/assets/24995224/113cfaac-0a02-4c06-80f4-5a8274032d4b">
