### PR TITLE
Included RSS feed in the header

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1,4 +1,7 @@
 <?php
+if( !defined('POWERPRESS_NO_REMOVE_WP_HEAD') ) {
+	define( 'POWERPRESS_NO_REMOVE_WP_HEAD', true );
+}
 
 /* remove  parent script that inserts ellipsis icon on mobile */
 function dequeue_priority_menu() {


### PR DESCRIPTION
The "Blubrry PowerPress" plugin was causing a problem with the main WordPress feed. To solve it, I enabled the default WordPress feed, and now everything works fine. Issue fixes #275